### PR TITLE
fix device state

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in the repo. 
 # Unless a later match takes precedence, the listed user will be 
 # requested for review when someone opens a pull request.
-# * @thkindler
+@thkindler

--- a/apax-lock.json
+++ b/apax-lock.json
@@ -13,74 +13,13 @@
     },
     "devDependencies": {
       "@ax/sdk": "^2504.0.0",
-      "@simatic-ax/snippetscollection": "^1.0.0"
+      "@simatic-ax/snippetscollection": "^1.1.0"
     },
     "catalogs": {
       "@ax/simatic-ax": "^2504.0.0"
     }
   },
   "packages": {
-    "@ax/sdk": {
-      "name": "@ax/sdk",
-      "version": "2504.0.0",
-      "integrity": "sha512-N/EKc3cmIEtfuHaz1q7sz4Rg3VA3xnS+hBXvtrT1kz9Aslm0In+v3lehzJoKtjhM5/RwX3yqjuIYtPKOY0nNqQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/sdk/-/sdk-2504.0.0.tgz",
-      "dependencies": {
-        "@ax/apax-build": "2.0.20",
-        "@ax/axunitst": "8.0.33",
-        "@ax/axunitst-ls-contrib": "8.0.33",
-        "@ax/certificate-management": "1.2.0",
-        "@ax/diagnostic-buffer": "1.3.2",
-        "@ax/hw-s7-1500": "3.0.0",
-        "@ax/hwc": "3.0.0",
-        "@ax/hwld": "3.0.0",
-        "@ax/mod": "1.7.6",
-        "@ax/mon": "1.7.6",
-        "@ax/performance-info": "1.1.2",
-        "@ax/plc-control": "1.2.50",
-        "@ax/plc-info": "3.1.0",
-        "@ax/sdb": "1.7.6",
-        "@ax/simatic-package-tool": "2.0.15",
-        "@ax/sld": "3.2.4",
-        "@ax/st-ls": "10.0.85",
-        "@ax/st-opcua.stc-plugin": "1.0.0",
-        "@ax/st-resources.stc-plugin": "3.0.23",
-        "@ax/stc": "10.0.85",
-        "@ax/target-llvm": "10.0.85",
-        "@ax/target-mc7plus": "10.0.85",
-        "@ax/trace": "2.9.0"
-      }
-    },
-    "@ax/system-timer": {
-      "name": "@ax/system-timer",
-      "version": "10.0.24",
-      "integrity": "sha512-n2ZW2Mbh+f5IHW7+yWgHGR8ddFtq7Px73rGZg/Iypvl2sfP8QZ4fz++M7rQGW+Jvk2w4NPjY1JqieLrpas27Lw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-timer/-/system-timer-10.0.24.tgz",
-      "dependencies": {}
-    },
-    "@ax/system-serde": {
-      "name": "@ax/system-serde",
-      "version": "10.0.24",
-      "integrity": "sha512-v29/WX/EiBsd/fJTCGNNEb6jfvrLYOklhlaPEmMaTlsF2swqNyWEfOuQ2etRZtUZS3r5tcSHpwRvGlDsmw45jQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-serde/-/system-serde-10.0.24.tgz",
-      "dependencies": {
-        "@ax/system-strings": "^10.0.24"
-      }
-    },
-    "@ax/simatic-1500-distributedio": {
-      "name": "@ax/simatic-1500-distributedio",
-      "version": "10.0.1",
-      "integrity": "sha512-ZuuwiTXyCcfr4tHGZZb0Wwu2imLZwgGyoa2mGlbcwh1iqXWiNrlOdsA81JSA5NnSXa8QZh9UtJo3za9N1al4lw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/simatic-1500-distributedio/-/simatic-1500-distributedio-10.0.1.tgz",
-      "dependencies": {}
-    },
-    "@simatic-ax/snippetscollection": {
-      "name": "@simatic-ax/snippetscollection",
-      "version": "1.0.0",
-      "integrity": "sha512-8BNldIIGZuuLSiMjJxcBmHt7sL7kSlc0dss88BcrfnL/7iXPmHwhlnh4XobcVoOHXaz5f8cbMbXCUrffBIwecQ==",
-      "resolved": "https://npm.pkg.github.com/download/@simatic-ax/snippetscollection/1.0.0/60302d7e0da15a914ce0126503398063a42e1917",
-      "dependencies": {}
-    },
     "@ax/apax-build": {
       "name": "@ax/apax-build",
       "version": "2.0.20",
@@ -90,20 +29,101 @@
     },
     "@ax/axunitst": {
       "name": "@ax/axunitst",
-      "version": "8.0.33",
-      "integrity": "sha512-75SMC8Vc+9LtSiSyYckJ06AnbQFtrB/lrgcnnSyM8VPqDtUh1tRFGVsvBNe4YiJ3ZXm1mXKv3ajwGgODCE7fxA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst/-/axunitst-8.0.33.tgz",
+      "version": "8.3.9",
+      "integrity": "sha512-5/2KSkV3YeU7WQ7MJGJzC6j4XFIldei8V8mDrYADOUjhW7Xo0RvFZpiRqdUatIOJmjx1YpMPlBdTH86ukwAyZA==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst/-/axunitst-8.3.9.tgz",
       "dependencies": {
-        "@ax/axunitst-library": "8.0.33",
-        "@ax/axunitst-test-director": "8.0.33",
+        "@ax/axunitst-library": "8.3.9",
+        "@ax/axunitst-test-director": "8.3.9",
         "@ax/build-native": "^16.0.3"
+      }
+    },
+    "@ax/axunitst-library": {
+      "name": "@ax/axunitst-library",
+      "version": "8.3.9",
+      "integrity": "sha512-k3LEoI4jKuXw6TYx2lvwB4uE36y112X4/lf8jFAoltAKlXuIDxwAsKHzDC7zkpKOpEW8QnOrtgAmcVck8MyV5Q==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst-library/-/axunitst-library-8.3.9.tgz",
+      "dependencies": {
+        "@ax/system-strings": "^10.0.24"
       }
     },
     "@ax/axunitst-ls-contrib": {
       "name": "@ax/axunitst-ls-contrib",
-      "version": "8.0.33",
-      "integrity": "sha512-FDAzrhGYq09PogiFOTq3X1Zg0SSUiNueyEREsuQtME0m/7h86jQvpOke2eMuXQjcP714MGoiEcwrCShn1kAiQg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst-ls-contrib/-/axunitst-ls-contrib-8.0.33.tgz",
+      "version": "8.3.9",
+      "integrity": "sha512-Xs7gtUN+sRFx19zsqJVVKa9JTsCxmwrGXtjUeE1IrNmH8BZ0XuUzxqgcVGH/UZhCa2QREmtkdP5P+SDIOVC+cA==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst-ls-contrib/-/axunitst-ls-contrib-8.3.9.tgz",
+      "dependencies": {}
+    },
+    "@ax/axunitst-test-director": {
+      "name": "@ax/axunitst-test-director",
+      "version": "8.3.9",
+      "integrity": "sha512-OV/T33oAYa3eI3++dAU0IxIhATWeSdpjvv78YrpaiWlUV7qrhvYxB2RS21Ww/HkQzb9STnsSUDSz1dzD+RLJ4Q==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst-test-director/-/axunitst-test-director-8.3.9.tgz",
+      "dependencies": {
+        "@ax/axunitst-test-director-linux-x64": "8.3.9",
+        "@ax/axunitst-test-director-win-x64": "8.3.9"
+      }
+    },
+    "@ax/axunitst-test-director-linux-x64": {
+      "name": "@ax/axunitst-test-director-linux-x64",
+      "version": "8.3.9",
+      "integrity": "sha512-22VBgNDKYVl4ArJC7s0o86KM8Y/PR4KvbU5YDSkGqdk9NDOgzg/shpEYkHCcOOpBLPRvGBEtCoGCJDmSN3m6Yg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst-test-director-linux-x64/-/axunitst-test-director-linux-x64-8.3.9.tgz",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "dependencies": {}
+    },
+    "@ax/axunitst-test-director-win-x64": {
+      "name": "@ax/axunitst-test-director-win-x64",
+      "version": "8.3.9",
+      "integrity": "sha512-IObrnkWVIVlzND0Ab+hj8eOrgm+bdQG9t0BVTi7ayxWmmAzlh/WrTAiH8cgLt7GAnu0oX72VfLI3BzmNodjuag==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst-test-director-win-x64/-/axunitst-test-director-win-x64-8.3.9.tgz",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "dependencies": {}
+    },
+    "@ax/build-native": {
+      "name": "@ax/build-native",
+      "version": "16.1.17",
+      "integrity": "sha512-MxzhTXI425dwQgqmhDmVVM885GPT39e6NPRegUZnXHtMUNlxR82F4oifc5rr9JmBwAM2XZ/TDKi/TBHNCaNhpg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/build-native/-/build-native-16.1.17.tgz",
+      "dependencies": {
+        "@ax/build-native-winx64": "16.1.17",
+        "@ax/build-native-linux": "16.1.17"
+      }
+    },
+    "@ax/build-native-linux": {
+      "name": "@ax/build-native-linux",
+      "version": "16.1.17",
+      "integrity": "sha512-45mKw828x0akm1CENzNefVhggMApddltdCgocM/n6snMWxPRJCmhazFmVxTSomOnOsEMuZDsl0eHUl4IvO/oZQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/build-native-linux/-/build-native-linux-16.1.17.tgz",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "dependencies": {}
+    },
+    "@ax/build-native-winx64": {
+      "name": "@ax/build-native-winx64",
+      "version": "16.1.17",
+      "integrity": "sha512-qv8r2ahouOQivHCWveGX/ktNTYvosf/aiHvZ6w1h7wAjAOgTjf7zhFZs07AquFmQ9rcUP0ZNPRBFziSvEmOmpA==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/build-native-winx64/-/build-native-winx64-16.1.17.tgz",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
       "dependencies": {}
     },
     "@ax/certificate-management": {
@@ -130,238 +150,18 @@
         "@ax/diagnostic-buffer-linux-x64": "1.3.2"
       }
     },
-    "@ax/hw-s7-1500": {
-      "name": "@ax/hw-s7-1500",
-      "version": "3.0.0",
-      "integrity": "sha512-iAyTgiwcjdkb25ofPz0UNtMAtTBXOfoaTq/60gjGAV9LeJQ+Dx4v5JkRNcMSCz1bX2TyKYfhTJSxtqdgJj5Xhg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hw-s7-1500/-/hw-s7-1500-3.0.0.tgz",
-      "dependencies": {}
-    },
-    "@ax/hwc": {
-      "name": "@ax/hwc",
-      "version": "3.0.0",
-      "integrity": "sha512-kMgipV3XWLt3VpP8G5EDu+Vv3ki2eQLpBwUtt49CBuWXGYs4Rajeb37kML/k4gs/i9TQBRcSBQZHBZti8us1xQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hwc/-/hwc-3.0.0.tgz",
-      "dependencies": {
-        "@ax/hwc-win-x64": "3.0.0",
-        "@ax/hwc-linux-x64": "3.0.0"
-      }
-    },
-    "@ax/hwld": {
-      "name": "@ax/hwld",
-      "version": "3.0.0",
-      "integrity": "sha512-l84LaJJUY6/ztD9ikFFZNbqv8Z6+KnNaoqWkZqtzHRjS+W/wU9NBkoTu9dR4leQsoSgSWKa9cFtSHyzdfTPuCg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hwld/-/hwld-3.0.0.tgz",
-      "cpu": [
-        "x64"
-      ],
-      "dependencies": {}
-    },
-    "@ax/mod": {
-      "name": "@ax/mod",
-      "version": "1.7.6",
-      "integrity": "sha512-+8eeLUJGyImq4YmgavJqPA9yMFt+/ASy5NiuHjK1xOJ84LoHQ6piGr3Yd0UbEHcieh9FirYmAKHwjMn3ftJl+A==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mod/-/mod-1.7.6.tgz",
-      "dependencies": {
-        "@ax/mod-win-x64": "1.7.6",
-        "@ax/mod-linux-x64": "1.7.6"
-      }
-    },
-    "@ax/mon": {
-      "name": "@ax/mon",
-      "version": "1.7.6",
-      "integrity": "sha512-LCz+0VKgEgdBGLQt7H/VCsEIu+rbFXkFPvfjry3/aBif8r5GE2hOTUmujnSiBgNDujpnoRQtbO7eqKCbwjb41A==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mon/-/mon-1.7.6.tgz",
-      "dependencies": {
-        "@ax/mon-win-x64": "1.7.6",
-        "@ax/mon-linux-x64": "1.7.6"
-      }
-    },
-    "@ax/performance-info": {
-      "name": "@ax/performance-info",
-      "version": "1.1.2",
-      "integrity": "sha512-CIgPtJrAUL/akDShp7fUvH9x+AxrI2QDkbH6zJ3sCFs25Auo8sLXWx+h60fG6m11Z+hNVDqe11VY6u0r7a9I5Q==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/performance-info/-/performance-info-1.1.2.tgz",
-      "dependencies": {
-        "@ax/performance-info-win-x64": "1.1.2",
-        "@ax/performance-info-linux-x64": "1.1.2"
-      }
-    },
-    "@ax/plc-control": {
-      "name": "@ax/plc-control",
-      "version": "1.2.50",
-      "integrity": "sha512-BH06GYbQc3Y9fkXU25VafYAnWUC89WtcvBxXUQ2Np0lqMip30QRCE3kzET7v7iMNz1zpvVZnnh2Wnngkyu0bqw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/plc-control/-/plc-control-1.2.50.tgz",
-      "cpu": [
-        "x64"
-      ],
-      "dependencies": {}
-    },
-    "@ax/plc-info": {
-      "name": "@ax/plc-info",
-      "version": "3.1.0",
-      "integrity": "sha512-BvmreWSiWO/h2deSP0hty6kwzZRobQ3bkvKmq3ejsjYtrQtf8QcC+BzHevRxyLxVYCllVmLNuynPvISYSaFQbw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/plc-info/-/plc-info-3.1.0.tgz",
+    "@ax/diagnostic-buffer-linux-x64": {
+      "name": "@ax/diagnostic-buffer-linux-x64",
+      "version": "1.3.2",
+      "integrity": "sha512-pnJWcBxVR9bfuNEcoxSVoVSfkcy2EaOo/mLUAL0yxcZqVyVxk29mQ+NOL6cflUwsMk8xdV5z2/TT1LUPN6Hw7Q==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/diagnostic-buffer-linux-x64/-/diagnostic-buffer-linux-x64-1.3.2.tgz",
       "os": [
-        "win32",
         "linux"
       ],
       "cpu": [
         "x64"
       ],
       "dependencies": {}
-    },
-    "@ax/sdb": {
-      "name": "@ax/sdb",
-      "version": "1.7.6",
-      "integrity": "sha512-94lnXmuoPezjPbqq/YT+XXI7rzu0zKeac8smULI00p1H2bsTFsHYwsW/rHc1LAsKSxKAhsUTLme56ahpyck2zw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/sdb/-/sdb-1.7.6.tgz",
-      "dependencies": {
-        "@ax/sdb-win-x64": "1.7.6",
-        "@ax/sdb-linux-x64": "1.7.6"
-      }
-    },
-    "@ax/simatic-package-tool": {
-      "name": "@ax/simatic-package-tool",
-      "version": "2.0.15",
-      "integrity": "sha512-oUZiRl32M2IXYxhZaHrHmwOopdhK1Pq92F+uGV0u9AI4MFsw+GKTBCygp2SNqwPckEjPxgy1RwKgHgEI88yyrA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/simatic-package-tool/-/simatic-package-tool-2.0.15.tgz",
-      "dependencies": {}
-    },
-    "@ax/sld": {
-      "name": "@ax/sld",
-      "version": "3.2.4",
-      "integrity": "sha512-KRGKm2dCl9alOcOc8Kty7NTHwVsyT19HBDP8k5Sv3L8Dj+S5Y4GinHoFNrlXv2wQVGNXV93ESMYFvjxdsqrOvw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/sld/-/sld-3.2.4.tgz",
-      "cpu": [
-        "x64"
-      ],
-      "dependencies": {}
-    },
-    "@ax/st-ls": {
-      "name": "@ax/st-ls",
-      "version": "10.0.85",
-      "integrity": "sha512-dBi/eQm7ImAIW3vBHrF0vTIq3ZD5IkElMfBQ/ep3WHQzs9uT3K5kYgTX5tuXj6epGGsvs52JCCxJSuyavDL8tg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-ls/-/st-ls-10.0.85.tgz",
-      "dependencies": {
-        "@ax/st-ls-win-x64": "10.0.85",
-        "@ax/st-ls-linux-x64": "10.0.85"
-      }
-    },
-    "@ax/st-opcua.stc-plugin": {
-      "name": "@ax/st-opcua.stc-plugin",
-      "version": "1.0.0",
-      "integrity": "sha512-vrcGgmscXJYea+j8fL4iq+MPNBzvK1ObAzcuZ9NYNFx8IfO94z2Vo8eiNBVAOH8tqycgKIfwzf1KRsqXsimgUg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-opcua.stc-plugin/-/st-opcua.stc-plugin-1.0.0.tgz",
-      "dependencies": {}
-    },
-    "@ax/st-resources.stc-plugin": {
-      "name": "@ax/st-resources.stc-plugin",
-      "version": "3.0.23",
-      "integrity": "sha512-lWYWtrrWnd+keI4sw+RcBjEz9oTVgV6wvTAnb2AcE3PHemiirvY52vl6w2OqIFbUMqfhVqpD7KDd83o/HEsAhg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-resources.stc-plugin/-/st-resources.stc-plugin-3.0.23.tgz",
-      "dependencies": {}
-    },
-    "@ax/stc": {
-      "name": "@ax/stc",
-      "version": "10.0.85",
-      "integrity": "sha512-2zgkFaQmYp9E6Twv/C05zJn37Ym+7UGFUs9aunabp+opWqlYioIToegXLzSlH5gEZ8wRZoIIJQ1YzH+9fxY65g==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc/-/stc-10.0.85.tgz",
-      "dependencies": {
-        "@ax/stc-win-x64": "10.0.85",
-        "@ax/stc-linux-x64": "10.0.85"
-      }
-    },
-    "@ax/target-llvm": {
-      "name": "@ax/target-llvm",
-      "version": "10.0.85",
-      "integrity": "sha512-3pWLWB/CaJHeJgRZDxoWi8WIx1Nipk5c4rkyhjrdUhx2nMFU0Ijb7RoeMVvcDHeQJOi37YoHWz4k7ZlrRJRpNw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-llvm/-/target-llvm-10.0.85.tgz",
-      "dependencies": {
-        "@ax/target-llvm-win-x64": "10.0.85",
-        "@ax/target-llvm-linux-x64": "10.0.85"
-      }
-    },
-    "@ax/target-mc7plus": {
-      "name": "@ax/target-mc7plus",
-      "version": "10.0.85",
-      "integrity": "sha512-b2hto1AUqCWCn3n7DS6XmBRc7XGASyLKLcRB8OEvIIgRPUCujpeKFY6Q0qwt3cbtdp9l1ticQF6/4RvmWcWGOg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-mc7plus/-/target-mc7plus-10.0.85.tgz",
-      "dependencies": {
-        "@ax/target-mc7plus-win-x64": "10.0.85",
-        "@ax/target-mc7plus-linux-x64": "10.0.85"
-      }
-    },
-    "@ax/trace": {
-      "name": "@ax/trace",
-      "version": "2.9.0",
-      "integrity": "sha512-ZTNI6hF+U6184d9hcZEMN+A/cTu8JhAG4N5NrlmoEudvgq+iWl++LYZwr5oVNCxZ+0tdOphOKmoQEYJTZGE2/A==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/trace/-/trace-2.9.0.tgz",
-      "dependencies": {
-        "@ax/trace-win-x64": "2.9.0",
-        "@ax/trace-linux-x64": "2.9.0"
-      }
-    },
-    "@ax/system-strings": {
-      "name": "@ax/system-strings",
-      "version": "10.0.24",
-      "integrity": "sha512-ujMjximtgfbifxVXG+a71oQWmtF2+cj3bR7GILTkbgRFNvg5/r5lBAWVnbCUtW+o1/3tPiLUj7yUqsqfqDXX2g==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-strings/-/system-strings-10.0.24.tgz",
-      "dependencies": {
-        "@ax/system-math": "^10.0.24",
-        "@ax/system-datetime": "^10.0.24",
-        "@ax/system-conversion": "^10.0.24"
-      }
-    },
-    "@ax/system-math": {
-      "name": "@ax/system-math",
-      "version": "10.0.24",
-      "integrity": "sha512-bdyToqd9eFG89/Xp/LjaCBC/6yNmy3Z2ynXb/KLsO0avJtgszWtVDW/0yLpB9RgGmzh9vh9feAS7AKgVv1cSPQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-math/-/system-math-10.0.24.tgz",
-      "dependencies": {}
-    },
-    "@ax/system-datetime": {
-      "name": "@ax/system-datetime",
-      "version": "10.0.24",
-      "integrity": "sha512-L4IoFzmAoeLXR3g0ThGJM30iIDDnXNhCNVKnEF4+eKjED6GlLozohpvm+UjdTW4H0+5zplqbe82T1DSpgN7LZg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-datetime/-/system-datetime-10.0.24.tgz",
-      "dependencies": {}
-    },
-    "@ax/system-conversion": {
-      "name": "@ax/system-conversion",
-      "version": "10.0.24",
-      "integrity": "sha512-vHK3X8HnmZsGh/5KEeBmkJ9oZBPEFwxKx2Juu1HU9BN/er6cIQCRJpJOr3JehERxqaIT+s0+/V5rfTeWe1hkPQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-conversion/-/system-conversion-10.0.24.tgz",
-      "dependencies": {}
-    },
-    "@ax/axunitst-library": {
-      "name": "@ax/axunitst-library",
-      "version": "8.0.33",
-      "integrity": "sha512-foVDUnQqjUmHiHGhf7Ty0K+HhlXEXM5r0SjnZgJlPFZtgnAI5yvGspGRq+/0zZjMrmEg8xnRDhWZLVtJsoxEIg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst-library/-/axunitst-library-8.0.33.tgz",
-      "dependencies": {
-        "@ax/system-strings": "^10.0.24"
-      }
-    },
-    "@ax/axunitst-test-director": {
-      "name": "@ax/axunitst-test-director",
-      "version": "8.0.33",
-      "integrity": "sha512-rH51qi/29Tz5Q5ZFTwtpKskpdg/M68ml+CEuhUYfzrQhUcEyGeJQSKBNXFcNrXyxcekD5aA1TwxPU2sPN9hMuA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst-test-director/-/axunitst-test-director-8.0.33.tgz",
-      "dependencies": {
-        "@ax/axunitst-test-director-linux-x64": "8.0.33",
-        "@ax/axunitst-test-director-win-x64": "8.0.33"
-      }
-    },
-    "@ax/build-native": {
-      "name": "@ax/build-native",
-      "version": "16.1.17",
-      "integrity": "sha512-MxzhTXI425dwQgqmhDmVVM885GPT39e6NPRegUZnXHtMUNlxR82F4oifc5rr9JmBwAM2XZ/TDKi/TBHNCaNhpg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/build-native/-/build-native-16.1.17.tgz",
-      "dependencies": {
-        "@ax/build-native-winx64": "16.1.17",
-        "@ax/build-native-linux": "16.1.17"
-      }
     },
     "@ax/diagnostic-buffer-win-x64": {
       "name": "@ax/diagnostic-buffer-win-x64",
@@ -376,11 +176,37 @@
       ],
       "dependencies": {}
     },
-    "@ax/diagnostic-buffer-linux-x64": {
-      "name": "@ax/diagnostic-buffer-linux-x64",
-      "version": "1.3.2",
-      "integrity": "sha512-pnJWcBxVR9bfuNEcoxSVoVSfkcy2EaOo/mLUAL0yxcZqVyVxk29mQ+NOL6cflUwsMk8xdV5z2/TT1LUPN6Hw7Q==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/diagnostic-buffer-linux-x64/-/diagnostic-buffer-linux-x64-1.3.2.tgz",
+    "@ax/hw-s7-1500": {
+      "name": "@ax/hw-s7-1500",
+      "version": "3.1.0",
+      "integrity": "sha512-837Q+4M9BJVRfqLZC24BsAufnLx7FSW5HI7quPHoY2zmudaahlPeVIgUWvaNxYKRulDb6aBj2px5SR98DyGUfw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hw-s7-1500/-/hw-s7-1500-3.1.0.tgz",
+      "dependencies": {
+        "@ax/hw-shared-s7-1500": "3.1.0"
+      }
+    },
+    "@ax/hw-shared-s7-1500": {
+      "name": "@ax/hw-shared-s7-1500",
+      "version": "3.1.0",
+      "integrity": "sha512-4T7QC8MHLpwY39H1yiQrlupWcOe5//Oo8APwMZ1fQ+5zgwitSE3df5rOiN/I87vtTdK7R6qU7fM0uxS5ROZLGQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hw-shared-s7-1500/-/hw-shared-s7-1500-3.1.0.tgz",
+      "dependencies": {}
+    },
+    "@ax/hwc": {
+      "name": "@ax/hwc",
+      "version": "3.1.0",
+      "integrity": "sha512-3IdrA5LkTwASLho11rH1ZrbOe1u6+VmcPpF3z2NuyNUyqakk/+lHgYsRbjjVI/WiR7fRzwERdcE9gWAM0XlNGQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hwc/-/hwc-3.1.0.tgz",
+      "dependencies": {
+        "@ax/hwc-win-x64": "3.1.0",
+        "@ax/hwc-linux-x64": "3.1.0"
+      }
+    },
+    "@ax/hwc-linux-x64": {
+      "name": "@ax/hwc-linux-x64",
+      "version": "3.1.0",
+      "integrity": "sha512-VEdFTAH0Xp+sEE66Hm+yQWZtnHlMAnx/D9nTfF8zNCOl/pEEEZB29pOojBC+Qixr3dI85bv5rD+tbwQ2jHDjWg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hwc-linux-x64/-/hwc-linux-x64-3.1.0.tgz",
       "os": [
         "linux"
       ],
@@ -391,9 +217,9 @@
     },
     "@ax/hwc-win-x64": {
       "name": "@ax/hwc-win-x64",
-      "version": "3.0.0",
-      "integrity": "sha512-rqU2J1fccx+sbM/ZQFJzM0gCD7BxIGP1r3Tzih3q9PRSVuKrIs8srFArMiDjN1KAP4BtZFix9knWGb7djlj6bQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hwc-win-x64/-/hwc-win-x64-3.0.0.tgz",
+      "version": "3.1.0",
+      "integrity": "sha512-+d9orFgEI/IQSjLiVRwsIsFFgep9DECNicg7jL56G37dzcENKm9hzMjYib9JBgje3kIPJzuCYI3wjLjfgXZULA==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hwc-win-x64/-/hwc-win-x64-3.1.0.tgz",
       "os": [
         "win32"
       ],
@@ -402,11 +228,31 @@
       ],
       "dependencies": {}
     },
-    "@ax/hwc-linux-x64": {
-      "name": "@ax/hwc-linux-x64",
-      "version": "3.0.0",
-      "integrity": "sha512-apyeDcxX0XD3q/9Oc0SfPIO9GLn60owsDg/xlu4WNVVjP20OhMnoc5l1f+p1nOJMf0I/tMfe4UIPxKQ6LxSTVQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hwc-linux-x64/-/hwc-linux-x64-3.0.0.tgz",
+    "@ax/hwld": {
+      "name": "@ax/hwld",
+      "version": "3.1.0",
+      "integrity": "sha512-1cuyX2X/nccQxgXrFhjG+Pr4Fbq0Ksk//BHKJ90l77Rr3nYYf4VSKquxFKD70jbwrtvamVM/QlOJaMA3tTNwTw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/hwld/-/hwld-3.1.0.tgz",
+      "cpu": [
+        "x64"
+      ],
+      "dependencies": {}
+    },
+    "@ax/mod": {
+      "name": "@ax/mod",
+      "version": "1.8.8",
+      "integrity": "sha512-X7KzfcPEylmA4bivRHV8QYy5unif8YOZyJ2EUmwtaSK22ypu114v2GcaQzOFG9eGECYasKgVQXvJRgOtBVYVyw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mod/-/mod-1.8.8.tgz",
+      "dependencies": {
+        "@ax/mod-win-x64": "1.8.8",
+        "@ax/mod-linux-x64": "1.8.8"
+      }
+    },
+    "@ax/mod-linux-x64": {
+      "name": "@ax/mod-linux-x64",
+      "version": "1.8.8",
+      "integrity": "sha512-88i2XcWX3M6OC+WqufvFqhDTyXUuYIHd+BLGWOP3IogWThoUSXHeKdXrPYX65AcBEsszkLpOCVPScBKOscR2/A==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mod-linux-x64/-/mod-linux-x64-1.8.8.tgz",
       "os": [
         "linux"
       ],
@@ -417,9 +263,9 @@
     },
     "@ax/mod-win-x64": {
       "name": "@ax/mod-win-x64",
-      "version": "1.7.6",
-      "integrity": "sha512-xn1p650bNmPQ9sa1g0V/kJzxZj8yRDIoG+2oBnvQKR5mHCSIQ2RWJ8P+Rabvypdm6wcZ40oy64iG65e0DUNMtw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mod-win-x64/-/mod-win-x64-1.7.6.tgz",
+      "version": "1.8.8",
+      "integrity": "sha512-MWMYv9SaLN3aRnMpfHIqOciPZ078Vd4SdOVKk1klJdQgk3iIujx2QJpNyyPUICROp9a10cD3wQNVfpHyNGQaUQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mod-win-x64/-/mod-win-x64-1.8.8.tgz",
       "os": [
         "win32"
       ],
@@ -428,11 +274,21 @@
       ],
       "dependencies": {}
     },
-    "@ax/mod-linux-x64": {
-      "name": "@ax/mod-linux-x64",
-      "version": "1.7.6",
-      "integrity": "sha512-BhncasF8atzlWgQJsU5JgH2kbrUk9bVyk8ftrCY0md/XY5xQBqXFtk3CicljxWs8pEZWEk2/vCfevOnSyTj2/A==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mod-linux-x64/-/mod-linux-x64-1.7.6.tgz",
+    "@ax/mon": {
+      "name": "@ax/mon",
+      "version": "1.8.8",
+      "integrity": "sha512-iesfGnKFd0IGRc1BAWEmeTWywyly54Y12wwMRuearow7IXDVNK+nyh8UCK7eiaI5J8qVbgQR3uFDTljX10Ec/w==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mon/-/mon-1.8.8.tgz",
+      "dependencies": {
+        "@ax/mon-win-x64": "1.8.8",
+        "@ax/mon-linux-x64": "1.8.8"
+      }
+    },
+    "@ax/mon-linux-x64": {
+      "name": "@ax/mon-linux-x64",
+      "version": "1.8.8",
+      "integrity": "sha512-AvtsteSkn2wOv4h/o/tA26GkwM1sR+59ChetHJnyC70/JDqe6TBpPgugQTqa6A3xwUvAB9z/HtT2oXSYqzhoGQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mon-linux-x64/-/mon-linux-x64-1.8.8.tgz",
       "os": [
         "linux"
       ],
@@ -443,9 +299,9 @@
     },
     "@ax/mon-win-x64": {
       "name": "@ax/mon-win-x64",
-      "version": "1.7.6",
-      "integrity": "sha512-plaSTwa17Vd44KN0OZ6QM0h1m4BuVebvVj48oVZjgcv5DOoEzas9W/jGdZYbEel0XSu+wiRMurAfSELVSStRsA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mon-win-x64/-/mon-win-x64-1.7.6.tgz",
+      "version": "1.8.8",
+      "integrity": "sha512-/xLBPgEU7OxmuErZXj1gizPgkIkG2LTh4b+sHMmxxBiYE0reYQ07WBTQ+/kGzoRcuqYHkaJLmxizCnY1tqFntQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mon-win-x64/-/mon-win-x64-1.8.8.tgz",
       "os": [
         "win32"
       ],
@@ -454,11 +310,21 @@
       ],
       "dependencies": {}
     },
-    "@ax/mon-linux-x64": {
-      "name": "@ax/mon-linux-x64",
-      "version": "1.7.6",
-      "integrity": "sha512-cWbb8nQV+rmKf+Hle7r51a5IpHGpFP6FpgeBZyWxqhVCNkDRsUxjH29DkiIFIgmraTRybIHiatyKq/DveoceWA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/mon-linux-x64/-/mon-linux-x64-1.7.6.tgz",
+    "@ax/performance-info": {
+      "name": "@ax/performance-info",
+      "version": "1.1.2",
+      "integrity": "sha512-CIgPtJrAUL/akDShp7fUvH9x+AxrI2QDkbH6zJ3sCFs25Auo8sLXWx+h60fG6m11Z+hNVDqe11VY6u0r7a9I5Q==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/performance-info/-/performance-info-1.1.2.tgz",
+      "dependencies": {
+        "@ax/performance-info-win-x64": "1.1.2",
+        "@ax/performance-info-linux-x64": "1.1.2"
+      }
+    },
+    "@ax/performance-info-linux-x64": {
+      "name": "@ax/performance-info-linux-x64",
+      "version": "1.1.2",
+      "integrity": "sha512-LkJkE7oYvsHsWz7OujiQcSldE18BbLhJ4478HtMMoU+76dtI8we2boB/EHPr3jSdIS5FztG8l7hZRA3/7GrOrQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/performance-info-linux-x64/-/performance-info-linux-x64-1.1.2.tgz",
       "os": [
         "linux"
       ],
@@ -480,11 +346,45 @@
       ],
       "dependencies": {}
     },
-    "@ax/performance-info-linux-x64": {
-      "name": "@ax/performance-info-linux-x64",
-      "version": "1.1.2",
-      "integrity": "sha512-LkJkE7oYvsHsWz7OujiQcSldE18BbLhJ4478HtMMoU+76dtI8we2boB/EHPr3jSdIS5FztG8l7hZRA3/7GrOrQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/performance-info-linux-x64/-/performance-info-linux-x64-1.1.2.tgz",
+    "@ax/plc-control": {
+      "name": "@ax/plc-control",
+      "version": "1.3.5",
+      "integrity": "sha512-uLgQhJAt/pN+I2IKRioc9hQ8lT7Lnx9CI/dwdqO4hwbh2S+cHSnBIAEqteO8LCXE3lLDL2IdNmxgaz7rKV0IZA==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/plc-control/-/plc-control-1.3.5.tgz",
+      "cpu": [
+        "x64"
+      ],
+      "dependencies": {}
+    },
+    "@ax/plc-info": {
+      "name": "@ax/plc-info",
+      "version": "3.1.0",
+      "integrity": "sha512-BvmreWSiWO/h2deSP0hty6kwzZRobQ3bkvKmq3ejsjYtrQtf8QcC+BzHevRxyLxVYCllVmLNuynPvISYSaFQbw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/plc-info/-/plc-info-3.1.0.tgz",
+      "os": [
+        "win32",
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "dependencies": {}
+    },
+    "@ax/sdb": {
+      "name": "@ax/sdb",
+      "version": "1.8.8",
+      "integrity": "sha512-LBDC+hejBT28qFmvfVpwRCE4ztdTRS+a9trTyKSp2u6WZAAXv1wGYR3NaiBuT2CCmdMV17RS8CTxQmMMTE5f7g==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/sdb/-/sdb-1.8.8.tgz",
+      "dependencies": {
+        "@ax/sdb-win-x64": "1.8.8",
+        "@ax/sdb-linux-x64": "1.8.8"
+      }
+    },
+    "@ax/sdb-linux-x64": {
+      "name": "@ax/sdb-linux-x64",
+      "version": "1.8.8",
+      "integrity": "sha512-ciNEoXgTebzdYwc3orececSJ2gx1xBgm8TycWe2Id+WqlBdvzbzWdN27FET7ZxyqXiYNNrzAQV5GHlO2whuvOQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/sdb-linux-x64/-/sdb-linux-x64-1.8.8.tgz",
       "os": [
         "linux"
       ],
@@ -495,9 +395,9 @@
     },
     "@ax/sdb-win-x64": {
       "name": "@ax/sdb-win-x64",
-      "version": "1.7.6",
-      "integrity": "sha512-bx105Qsv0MaK6sOUl7EpX5+KprSpiAer2RWTxn7PKR/7R60eAwU7jwKQOZsq+nDO9KeErhMMNlUeNk6p3FF5hA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/sdb-win-x64/-/sdb-win-x64-1.7.6.tgz",
+      "version": "1.8.8",
+      "integrity": "sha512-95Os4pdG9rLsgpF20pfCgHcSHQTkQCJVJZlJh0mNjvBxwo3RZB9caYuoOSWQ51dE2zERYROZbYfDjCOVglitQg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/sdb-win-x64/-/sdb-win-x64-1.8.8.tgz",
       "os": [
         "win32"
       ],
@@ -506,11 +406,83 @@
       ],
       "dependencies": {}
     },
-    "@ax/sdb-linux-x64": {
-      "name": "@ax/sdb-linux-x64",
-      "version": "1.7.6",
-      "integrity": "sha512-3bbzAYc939iCdzWoIZwKA5j9//mQUOd4XX3659MvQispcABv5vz3zZ8dwyf+nhLXmgTm6IHRwleI57ZsYAI0nA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/sdb-linux-x64/-/sdb-linux-x64-1.7.6.tgz",
+    "@ax/sdk": {
+      "name": "@ax/sdk",
+      "version": "2504.1.2",
+      "integrity": "sha512-s7p7D1qftnHhOADpJNtvxrlxzqNN+NLK63BEDj4+opSxCLUKrp2qGLfRNh4g7RqprqjBUsqq06QAkVSMB5tt5w==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/sdk/-/sdk-2504.1.2.tgz",
+      "dependencies": {
+        "@ax/apax-build": "2.0.20",
+        "@ax/axunitst": "8.3.9",
+        "@ax/axunitst-ls-contrib": "8.3.9",
+        "@ax/certificate-management": "1.2.0",
+        "@ax/diagnostic-buffer": "1.3.2",
+        "@ax/hw-s7-1500": "3.1.0",
+        "@ax/hwc": "3.1.0",
+        "@ax/hwld": "3.1.0",
+        "@ax/mod": "1.8.8",
+        "@ax/mon": "1.8.8",
+        "@ax/performance-info": "1.1.2",
+        "@ax/plc-control": "1.3.5",
+        "@ax/plc-info": "3.1.0",
+        "@ax/sdb": "1.8.8",
+        "@ax/simatic-package-tool": "2.0.15",
+        "@ax/sld": "3.3.3",
+        "@ax/st-ls": "10.2.95",
+        "@ax/st-opcua.stc-plugin": "1.1.0",
+        "@ax/st-resources.stc-plugin": "3.0.23",
+        "@ax/stc": "10.2.95",
+        "@ax/target-llvm": "10.2.95",
+        "@ax/target-mc7plus": "10.2.95",
+        "@ax/trace": "2.9.1"
+      }
+    },
+    "@ax/simatic-1500-distributedio": {
+      "name": "@ax/simatic-1500-distributedio",
+      "version": "10.0.1",
+      "integrity": "sha512-ZuuwiTXyCcfr4tHGZZb0Wwu2imLZwgGyoa2mGlbcwh1iqXWiNrlOdsA81JSA5NnSXa8QZh9UtJo3za9N1al4lw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/simatic-1500-distributedio/-/simatic-1500-distributedio-10.0.1.tgz",
+      "dependencies": {}
+    },
+    "@ax/simatic-package-tool": {
+      "name": "@ax/simatic-package-tool",
+      "version": "2.0.15",
+      "integrity": "sha512-oUZiRl32M2IXYxhZaHrHmwOopdhK1Pq92F+uGV0u9AI4MFsw+GKTBCygp2SNqwPckEjPxgy1RwKgHgEI88yyrA==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/simatic-package-tool/-/simatic-package-tool-2.0.15.tgz",
+      "dependencies": {}
+    },
+    "@ax/sld": {
+      "name": "@ax/sld",
+      "version": "3.3.3",
+      "integrity": "sha512-+Behv0LgUD9A/v8Uy1hPtz17pqiFCJDTjXnyCe8MR0yxjQIRStMAkTjNkIwBwPLClAT9O0kSh6z3TWPluKlRHg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/sld/-/sld-3.3.3.tgz",
+      "cpu": [
+        "x64"
+      ],
+      "dependencies": {}
+    },
+    "@ax/st-docs": {
+      "name": "@ax/st-docs",
+      "version": "10.2.95",
+      "integrity": "sha512-y514g6zYkuZMg3i2tQ+Fjfl+HKKOmn6wkOFSpxQdsLKLfQIBuhx+2bXLMJcS+r9g/96pIYQlogiNNd6WBeUNWQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-docs/-/st-docs-10.2.95.tgz",
+      "dependencies": {}
+    },
+    "@ax/st-ls": {
+      "name": "@ax/st-ls",
+      "version": "10.2.95",
+      "integrity": "sha512-McI9PrrgaFyHWYpLFiGi8jzGXJNdZQHRtLkIpwDo0DNl55e7YpETWyFheBXdAwItpOwq6RTYFVC3Gw6fbgcTZw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-ls/-/st-ls-10.2.95.tgz",
+      "dependencies": {
+        "@ax/st-ls-win-x64": "10.2.95",
+        "@ax/st-ls-linux-x64": "10.2.95"
+      }
+    },
+    "@ax/st-ls-linux-x64": {
+      "name": "@ax/st-ls-linux-x64",
+      "version": "10.2.95",
+      "integrity": "sha512-jnib6eqi2mcnRZpzoCMqJ7Vi3M+mRf9+4j3kctmcRQGnhkX7oMtrZDqJMVgrdZ64WHmHgSIp5Tfq9F9xdnbfcg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-ls-linux-x64/-/st-ls-linux-x64-10.2.95.tgz",
       "os": [
         "linux"
       ],
@@ -521,9 +493,9 @@
     },
     "@ax/st-ls-win-x64": {
       "name": "@ax/st-ls-win-x64",
-      "version": "10.0.85",
-      "integrity": "sha512-CPwfQ0F9exIjGOkbSAfFNY/Msbs8U+ED2nVT68hqk6X3tRQGOn5Trs4qfc+x9WLAXAeXUCUrkv+5CGElURaM5A==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-ls-win-x64/-/st-ls-win-x64-10.0.85.tgz",
+      "version": "10.2.95",
+      "integrity": "sha512-FC4mgR/OrF0I4CkTdrqFDcjpUmPZTQAZuGmR8GEqKt4SskyIdtr6Z7FhD7OELrn2pjO+8tp5YtZCC21QK4sLdA==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-ls-win-x64/-/st-ls-win-x64-10.2.95.tgz",
       "os": [
         "win32"
       ],
@@ -532,39 +504,35 @@
       ],
       "dependencies": {}
     },
-    "@ax/st-ls-linux-x64": {
-      "name": "@ax/st-ls-linux-x64",
-      "version": "10.0.85",
-      "integrity": "sha512-iGG7IloIUZuYlZEC/kVgmSqc6E7S59BXgtZAOarRRuIsMvfumFtKYwgCmmqsM1v4WHcwi8mp2TJpFGJ78l4Vew==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-ls-linux-x64/-/st-ls-linux-x64-10.0.85.tgz",
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ],
+    "@ax/st-opcua.stc-plugin": {
+      "name": "@ax/st-opcua.stc-plugin",
+      "version": "1.1.0",
+      "integrity": "sha512-cgGzZLzPUurEYZT061GwhE8gLkmmnVv6frERhAuv3Zq9dj9n8oUTBN8uB8G1OF7plsK4X84/j+7GNec9swBtFg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-opcua.stc-plugin/-/st-opcua.stc-plugin-1.1.0.tgz",
       "dependencies": {}
     },
-    "@ax/stc-win-x64": {
-      "name": "@ax/stc-win-x64",
-      "version": "10.0.85",
-      "integrity": "sha512-oQO4gqnQECgFeJgFQ9NpBp6823E+LaGN/7EptAQiXcOmxP7rLWx+k61x26ckjHOk/2gV6/FOz6Dqa6fYUumsjg==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc-win-x64/-/stc-win-x64-10.0.85.tgz",
-      "os": [
-        "win32"
-      ],
-      "cpu": [
-        "x64"
-      ],
+    "@ax/st-resources.stc-plugin": {
+      "name": "@ax/st-resources.stc-plugin",
+      "version": "3.0.23",
+      "integrity": "sha512-lWYWtrrWnd+keI4sw+RcBjEz9oTVgV6wvTAnb2AcE3PHemiirvY52vl6w2OqIFbUMqfhVqpD7KDd83o/HEsAhg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-resources.stc-plugin/-/st-resources.stc-plugin-3.0.23.tgz",
+      "dependencies": {}
+    },
+    "@ax/stc": {
+      "name": "@ax/stc",
+      "version": "10.2.95",
+      "integrity": "sha512-viq12T+jCe5k+2E+dII5vM4nDkGKCxTxM4XpMSAe7yGw8kDFIVaWoT7k1+V74/HYJzfNxLNiu+vgAIOxjwDcNw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc/-/stc-10.2.95.tgz",
       "dependencies": {
-        "@ax/st-docs": "10.0.85"
+        "@ax/stc-win-x64": "10.2.95",
+        "@ax/stc-linux-x64": "10.2.95"
       }
     },
     "@ax/stc-linux-x64": {
       "name": "@ax/stc-linux-x64",
-      "version": "10.0.85",
-      "integrity": "sha512-4Hyi5+o1NT5+dAGwODznaVWd1yksNNXOp/5q+yvpWmuCJ74BLfMHLidK7ftLPQ68qFY9TEcpCjjuJ7Pdur5Wzw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc-linux-x64/-/stc-linux-x64-10.0.85.tgz",
+      "version": "10.2.95",
+      "integrity": "sha512-opMEOqwBpM1TnKvBvVmuDdo9cuM5OE6CO6Sh8zpay5F7Qujz/szeGSclIp1dhyUfuSIjorHmIVRZpWHq6H7aWw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc-linux-x64/-/stc-linux-x64-10.2.95.tgz",
       "os": [
         "linux"
       ],
@@ -572,14 +540,100 @@
         "x64"
       ],
       "dependencies": {
-        "@ax/st-docs": "10.0.85"
+        "@ax/st-docs": "10.2.95"
       }
+    },
+    "@ax/stc-win-x64": {
+      "name": "@ax/stc-win-x64",
+      "version": "10.2.95",
+      "integrity": "sha512-kR0PDVI0gxxSCeAxebiLrn2nYD/w4mD52oZYC3K7FGEr77vZCoUqARUBaShmJJrZLDw9q0mefUvFMo/3oWerQw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/stc-win-x64/-/stc-win-x64-10.2.95.tgz",
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "dependencies": {
+        "@ax/st-docs": "10.2.95"
+      }
+    },
+    "@ax/system-conversion": {
+      "name": "@ax/system-conversion",
+      "version": "10.0.24",
+      "integrity": "sha512-vHK3X8HnmZsGh/5KEeBmkJ9oZBPEFwxKx2Juu1HU9BN/er6cIQCRJpJOr3JehERxqaIT+s0+/V5rfTeWe1hkPQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-conversion/-/system-conversion-10.0.24.tgz",
+      "dependencies": {}
+    },
+    "@ax/system-datetime": {
+      "name": "@ax/system-datetime",
+      "version": "10.0.24",
+      "integrity": "sha512-L4IoFzmAoeLXR3g0ThGJM30iIDDnXNhCNVKnEF4+eKjED6GlLozohpvm+UjdTW4H0+5zplqbe82T1DSpgN7LZg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-datetime/-/system-datetime-10.0.24.tgz",
+      "dependencies": {}
+    },
+    "@ax/system-math": {
+      "name": "@ax/system-math",
+      "version": "10.0.24",
+      "integrity": "sha512-bdyToqd9eFG89/Xp/LjaCBC/6yNmy3Z2ynXb/KLsO0avJtgszWtVDW/0yLpB9RgGmzh9vh9feAS7AKgVv1cSPQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-math/-/system-math-10.0.24.tgz",
+      "dependencies": {}
+    },
+    "@ax/system-serde": {
+      "name": "@ax/system-serde",
+      "version": "10.0.24",
+      "integrity": "sha512-v29/WX/EiBsd/fJTCGNNEb6jfvrLYOklhlaPEmMaTlsF2swqNyWEfOuQ2etRZtUZS3r5tcSHpwRvGlDsmw45jQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-serde/-/system-serde-10.0.24.tgz",
+      "dependencies": {
+        "@ax/system-strings": "^10.0.24"
+      }
+    },
+    "@ax/system-strings": {
+      "name": "@ax/system-strings",
+      "version": "10.0.24",
+      "integrity": "sha512-ujMjximtgfbifxVXG+a71oQWmtF2+cj3bR7GILTkbgRFNvg5/r5lBAWVnbCUtW+o1/3tPiLUj7yUqsqfqDXX2g==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-strings/-/system-strings-10.0.24.tgz",
+      "dependencies": {
+        "@ax/system-math": "^10.0.24",
+        "@ax/system-datetime": "^10.0.24",
+        "@ax/system-conversion": "^10.0.24"
+      }
+    },
+    "@ax/system-timer": {
+      "name": "@ax/system-timer",
+      "version": "10.0.24",
+      "integrity": "sha512-n2ZW2Mbh+f5IHW7+yWgHGR8ddFtq7Px73rGZg/Iypvl2sfP8QZ4fz++M7rQGW+Jvk2w4NPjY1JqieLrpas27Lw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/system-timer/-/system-timer-10.0.24.tgz",
+      "dependencies": {}
+    },
+    "@ax/target-llvm": {
+      "name": "@ax/target-llvm",
+      "version": "10.2.95",
+      "integrity": "sha512-4lXrA8UjmzOD6rBAg0+8TmvjklRYrncm1KwB5pwkqkoik0NOOBHGQRyuwrYUL1dEWI1gP4i7FUemNyyKx57ZyQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-llvm/-/target-llvm-10.2.95.tgz",
+      "dependencies": {
+        "@ax/target-llvm-win-x64": "10.2.95",
+        "@ax/target-llvm-linux-x64": "10.2.95"
+      }
+    },
+    "@ax/target-llvm-linux-x64": {
+      "name": "@ax/target-llvm-linux-x64",
+      "version": "10.2.95",
+      "integrity": "sha512-PXpbCaOoXJ2sRVYkRq7wgui8rNWC6BxEzUOrPfQ5IyiGny5q1bHwWImL0utMjlf6dqPBb447w3P7ROLhp4Av9A==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-llvm-linux-x64/-/target-llvm-linux-x64-10.2.95.tgz",
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "dependencies": {}
     },
     "@ax/target-llvm-win-x64": {
       "name": "@ax/target-llvm-win-x64",
-      "version": "10.0.85",
-      "integrity": "sha512-VnD2ZkrwFM+DntZwVpVSwnQw6fNP7XPmhJFmuFMvzb+In82W6x8Rt9xpefh8Gin+qi9Ab3mrFP7wJSU36zNbxQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-llvm-win-x64/-/target-llvm-win-x64-10.0.85.tgz",
+      "version": "10.2.95",
+      "integrity": "sha512-+n5Lf2lZkifDFL1TJ363c2hyqCcHGuCoEij72wUdmMG9dXRlKP3EtI+MWvdxZriWDEY0izc75tmhme8vk8bFlQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-llvm-win-x64/-/target-llvm-win-x64-10.2.95.tgz",
       "os": [
         "win32"
       ],
@@ -588,11 +642,21 @@
       ],
       "dependencies": {}
     },
-    "@ax/target-llvm-linux-x64": {
-      "name": "@ax/target-llvm-linux-x64",
-      "version": "10.0.85",
-      "integrity": "sha512-NiEYT+A0GwXjv6h9esPRBT2rMFWDUWKrs2/e5rlvYzBqun2JxEWGNs7TVZzI9lF/ugRJ2AGvi2WFNF29ohesZw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-llvm-linux-x64/-/target-llvm-linux-x64-10.0.85.tgz",
+    "@ax/target-mc7plus": {
+      "name": "@ax/target-mc7plus",
+      "version": "10.2.95",
+      "integrity": "sha512-8XmMJBPSBRnMYjhXHcpZwRMqp+kHm8IHupFzoj/dFQyXvbe3pCJYHLi5pDg/sztsXkTmFksEhXfL2jPcQykDBg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-mc7plus/-/target-mc7plus-10.2.95.tgz",
+      "dependencies": {
+        "@ax/target-mc7plus-win-x64": "10.2.95",
+        "@ax/target-mc7plus-linux-x64": "10.2.95"
+      }
+    },
+    "@ax/target-mc7plus-linux-x64": {
+      "name": "@ax/target-mc7plus-linux-x64",
+      "version": "10.2.95",
+      "integrity": "sha512-jRAb11Vq5ElcJnaP6q8dW8NQ6MEyQBNIF/CDPRRGWdnjRJNTpzcUtAbr4FgMBdN4sQCq3/xYDcErDN5UDArfzg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-mc7plus-linux-x64/-/target-mc7plus-linux-x64-10.2.95.tgz",
       "os": [
         "linux"
       ],
@@ -603,9 +667,9 @@
     },
     "@ax/target-mc7plus-win-x64": {
       "name": "@ax/target-mc7plus-win-x64",
-      "version": "10.0.85",
-      "integrity": "sha512-mF4e3chyTBhdG+/YKVBFt/qLRzq4rQbP/H8N8Je084GxYG8bz9XUKkMy3vrIs5Kf8PG3BO+kmCEsjqqircPkYw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-mc7plus-win-x64/-/target-mc7plus-win-x64-10.0.85.tgz",
+      "version": "10.2.95",
+      "integrity": "sha512-yAhVaN1qjC6y83O/TKC0MXKVjJPcPG3zzubm0iqjS+r8tvD8Bn89VLg9GtLdzuOA1eCwhQC/y1/xk3RS44vyoA==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-mc7plus-win-x64/-/target-mc7plus-win-x64-10.2.95.tgz",
       "os": [
         "win32"
       ],
@@ -614,11 +678,21 @@
       ],
       "dependencies": {}
     },
-    "@ax/target-mc7plus-linux-x64": {
-      "name": "@ax/target-mc7plus-linux-x64",
-      "version": "10.0.85",
-      "integrity": "sha512-caFRNigisDgE0UAXv123WY7qSt+goc0tY2a0Pnq1TMlK4d1IWOzCBgYKEBJe29FLohQZGG472/KWgUMEnow4vQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/target-mc7plus-linux-x64/-/target-mc7plus-linux-x64-10.0.85.tgz",
+    "@ax/trace": {
+      "name": "@ax/trace",
+      "version": "2.9.1",
+      "integrity": "sha512-ihjX9dtHHrAwBdeMgrKD6qL+0end9pBw8RtnrgXJ0g63mzNGhn8T2kYedX1L2w+ZobHsMvz4rTP15G6Yzsc6tg==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/trace/-/trace-2.9.1.tgz",
+      "dependencies": {
+        "@ax/trace-win-x64": "2.9.1",
+        "@ax/trace-linux-x64": "2.9.1"
+      }
+    },
+    "@ax/trace-linux-x64": {
+      "name": "@ax/trace-linux-x64",
+      "version": "2.9.1",
+      "integrity": "sha512-SMQB4cDgj3Zf0ByUkRi15Z9UcGzpjkprsC4bBHgEgn9JsKH+rF6PJgaTb1Ol8IfrS+C6Dq8zZgxsQRE4IfHzYQ==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/trace-linux-x64/-/trace-linux-x64-2.9.1.tgz",
       "os": [
         "linux"
       ],
@@ -629,9 +703,9 @@
     },
     "@ax/trace-win-x64": {
       "name": "@ax/trace-win-x64",
-      "version": "2.9.0",
-      "integrity": "sha512-cWSDUbc8v1FNiIBq1Wk2ZMtuTbWNfGdbVRVVmq1XgxvwKncAsPgRMvUXM1Tv42sF9tI8ioIH0dRWel7U/PUGRw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/trace-win-x64/-/trace-win-x64-2.9.0.tgz",
+      "version": "2.9.1",
+      "integrity": "sha512-pntVcLy7aykIWv1+G+1mLD2OojKH2eiJT3TNm8aXyOrwpManrbUttRuTPpPvNZQ4esxGdW8AIZGRYbIU7CHAtw==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/trace-win-x64/-/trace-win-x64-2.9.1.tgz",
       "os": [
         "win32"
       ],
@@ -640,76 +714,11 @@
       ],
       "dependencies": {}
     },
-    "@ax/trace-linux-x64": {
-      "name": "@ax/trace-linux-x64",
-      "version": "2.9.0",
-      "integrity": "sha512-MJkRCJuKTX6DzpG30B+C0VuYeuQbjFbx5qAE5mJxij10WEAaf4MEylfBc394Tlsjcc9eJ99aSmIhxtI3SD3amQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/trace-linux-x64/-/trace-linux-x64-2.9.0.tgz",
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "dependencies": {}
-    },
-    "@ax/axunitst-test-director-linux-x64": {
-      "name": "@ax/axunitst-test-director-linux-x64",
-      "version": "8.0.33",
-      "integrity": "sha512-07ywM1OZiA2giHDXiGkVjNrgKI0TTasZo7tdpyg8mpkuAO7Tu8nXSBUFN/wGg3hVkmS81vh1cLnHHMIa3kkr9A==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst-test-director-linux-x64/-/axunitst-test-director-linux-x64-8.0.33.tgz",
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "dependencies": {}
-    },
-    "@ax/axunitst-test-director-win-x64": {
-      "name": "@ax/axunitst-test-director-win-x64",
-      "version": "8.0.33",
-      "integrity": "sha512-dGWVs5AqvedaUN52V8e+7KUq/UQju/ZXxP/W+vly9bG60sNIqLiLvtoNiBt32me4nWRDdKzhn+/uKCw5ITDJxA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/axunitst-test-director-win-x64/-/axunitst-test-director-win-x64-8.0.33.tgz",
-      "os": [
-        "win32"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "dependencies": {}
-    },
-    "@ax/build-native-winx64": {
-      "name": "@ax/build-native-winx64",
-      "version": "16.1.17",
-      "integrity": "sha512-qv8r2ahouOQivHCWveGX/ktNTYvosf/aiHvZ6w1h7wAjAOgTjf7zhFZs07AquFmQ9rcUP0ZNPRBFziSvEmOmpA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/build-native-winx64/-/build-native-winx64-16.1.17.tgz",
-      "os": [
-        "win32"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "dependencies": {}
-    },
-    "@ax/build-native-linux": {
-      "name": "@ax/build-native-linux",
-      "version": "16.1.17",
-      "integrity": "sha512-45mKw828x0akm1CENzNefVhggMApddltdCgocM/n6snMWxPRJCmhazFmVxTSomOnOsEMuZDsl0eHUl4IvO/oZQ==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/build-native-linux/-/build-native-linux-16.1.17.tgz",
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "dependencies": {}
-    },
-    "@ax/st-docs": {
-      "name": "@ax/st-docs",
-      "version": "10.0.85",
-      "integrity": "sha512-AWnR0yWP7cO+Ep97VWDPPr0hT/y9SJYNtj81PZdmML60fa6OM6hdVGqKgEzgUz/jwfkNTdE7yHnyUewjmx3ehA==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/st-docs/-/st-docs-10.0.85.tgz",
+    "@simatic-ax/snippetscollection": {
+      "name": "@simatic-ax/snippetscollection",
+      "version": "1.1.0",
+      "integrity": "sha512-aDktdAjTFVtWiOVSb5+7r1rdXsHZuyVnSO54CODKqxMZPl2CQjnemKZaBlPh+3CEdrk2O4/GWOR0msvr1vWn6g==",
+      "resolved": "https://npm.pkg.github.com/download/@simatic-ax/snippetscollection/1.1.0/42d6ab2b257a9d7f7cb24161f178f5f429e98c57",
       "dependencies": {}
     }
   },
@@ -717,27 +726,27 @@
   "catalogs": {
     "@ax/simatic-ax": {
       "name": "@ax/simatic-ax",
-      "version": "2504.0.0",
-      "integrity": "sha512-eN/1a893Pm8y0RL9/fdeCi8wFrpUrGQ8AiEpD6C/nBbUu9BT2LthySN2x9Fp8fLirhZV+SnHU3GVvQiLgIutBw==",
-      "resolved": "https://registry.simatic-ax.siemens.io/@ax/simatic-ax/-/simatic-ax-2504.0.0.tgz",
+      "version": "2504.1.2",
+      "integrity": "sha512-mrklvjYLpiKawlqKC0kfHLfczIZXbfP+Gkdj+4hwqsBWefkKb3o5X8nfhoeJmZ25KwH9003B6H6fadSs6Uns1Q==",
+      "resolved": "https://registry.simatic-ax.siemens.io/@ax/simatic-ax/-/simatic-ax-2504.1.2.tgz",
       "dependencies": {},
       "catalogDependencies": {
-        "@ax/stc": "10.0.85",
-        "@ax/target-mc7plus": "10.0.85",
-        "@ax/target-llvm": "10.0.85",
-        "@ax/st-ls": "10.0.85",
+        "@ax/stc": "10.2.95",
+        "@ax/target-mc7plus": "10.2.95",
+        "@ax/target-llvm": "10.2.95",
+        "@ax/st-ls": "10.2.95",
         "@ax/apax-build": "2.0.20",
         "@ax/build-native": "16.1.17",
-        "@ax/axunitst": "8.0.33",
-        "@ax/axunitst-ls-contrib": "8.0.33",
-        "@ax/axunitst-library": "8.0.33",
-        "@ax/axunit-mocking": "8.0.33",
-        "@ax/sld": "3.2.4",
-        "@ax/plc-control": "1.2.50",
-        "@ax/mod": "1.7.6",
-        "@ax/mon": "1.7.6",
-        "@ax/sdb": "1.7.6",
-        "@ax/trace": "2.9.0",
+        "@ax/axunitst": "8.3.9",
+        "@ax/axunitst-ls-contrib": "8.3.9",
+        "@ax/axunitst-library": "8.3.9",
+        "@ax/axunit-mocking": "8.3.9",
+        "@ax/sld": "3.3.3",
+        "@ax/plc-control": "1.3.5",
+        "@ax/mod": "1.8.8",
+        "@ax/mon": "1.8.8",
+        "@ax/sdb": "1.8.8",
+        "@ax/trace": "2.9.1",
         "@ax/diagnostic-buffer": "1.3.2",
         "@ax/certificate-management": "1.2.0",
         "@ax/hardware-diagnostics": "0.3.0",
@@ -764,9 +773,9 @@
         "@ax/dcp-utility": "1.2.0",
         "@ax/ax2tia": "11.0.18",
         "@ax/plc-info": "3.1.0",
-        "@ax/hwc": "3.0.0",
-        "@ax/hw-s7-1500": "3.0.0",
-        "@ax/hwld": "3.0.0",
+        "@ax/hwc": "3.1.0",
+        "@ax/hw-s7-1500": "3.1.0",
+        "@ax/hwld": "3.1.0",
         "@ax/system": "10.0.24",
         "@ax/system-bitaccess": "10.0.24",
         "@ax/system-conversion": "10.0.24",
@@ -784,14 +793,12 @@
         "@ax/simatic-1500-crypto": "3.0.2",
         "@ax/simatic-1500-diagnostics": "4.0.2",
         "@ax/simatic-package-tool": "2.0.15",
-        "@ax/st-opcua.stc-plugin": "1.0.0",
+        "@ax/st-opcua.stc-plugin": "1.1.0",
         "@ax/st-resources.stc-plugin": "3.0.23",
-        "@ax/xlad-transpile-cli": "1.2.0",
-        "@ax/st-lang-contrib-xlad": "1.2.0",
         "@ax/simatic-1500-pointtopoint": "3.0.4",
         "@ax/simatic-1500-modbusrtu": "3.0.5",
         "@ax/simatic-1500-technology-objects": "3.0.8",
-        "@ax/sdk": "2504.0.0"
+        "@ax/sdk": "2504.1.2"
       }
     }
   }

--- a/apax.yml
+++ b/apax.yml
@@ -24,14 +24,13 @@ catalogs:
 # Dependencies
 devDependencies:
   '@ax/sdk': ^2504.0.0
-  "@simatic-ax/snippetscollection": ^1.0.0
+  "@simatic-ax/snippetscollection": ^1.1.0
 dependencies:
   #system packages
   "@ax/system-timer": ^10.0.24
   "@ax/system-serde": ^10.0.24
   #simatic-1500-specific system packages
   "@ax/simatic-1500-distributedio": ^10.0.1
-
   # Project variables
 variables:
   APAX_BUILD_ARGS:

--- a/src/blocks/Device.st
+++ b/src/blocks/Device.st
@@ -138,11 +138,11 @@ NAMESPACE Simatic.Ax.IOLink
                 //found no issues, return TRUE
                 ReadWriteReqInternal := TRUE;
                 statBusy := TRUE;
+                statDone := FALSE;
+                statError := FALSE;
 
                 //check if cap needs to be read out before accessing the device
-                IF statcap <> UINT#0 THEN
-                    statFBState := StateDevice#FB_STATE_PREPARE_WRITE;
-                ELSIF (statCap <> TO_UINT(Cap#CAP_STANDARD) AND statCap <> TO_UINT(Cap#CAP_LEGACY)) OR (statHwIDprevious <> statHwID) THEN // check if new device is connected => hwID changed
+                IF (statCap <> TO_UINT(Cap#CAP_STANDARD) AND statCap <> TO_UINT(Cap#CAP_LEGACY)) OR (statHwIDprevious <> statHwID) THEN // check if new device is connected => hwID changed
                     statFBState := StateDevice#FB_STATE_READ_CAP;
                 ELSE
                     statFBState := StateDevice#FB_STATE_PREPARE_WRITE;
@@ -178,7 +178,7 @@ NAMESPACE Simatic.Ax.IOLink
                         IF (instRdRec.VALID = FALSE) AND (instRdRec.ERROR = FALSE) THEN
                             IF instRdRec.request = FALSE THEN
                                 // call read record with Index 16#B000
-                                instRdRec.request := true;
+                                instRdRec.request := TRUE;
                                 instRdRec.ID := statHwID;
                                 instRdRec.index := TO_UINT(Cap#INDEX_CAP_IOLINK);
                                 instRdRec.maxLength := UINT#0;


### PR DESCRIPTION
Fix: After a command for the device-class ran through, 'done' was active. When starting the next command, 'done' was active, while 'busy' was also busy, leading to an illegal state.